### PR TITLE
fix `Cannot resolve module '.temp_bundle_helpers.js'` problem

### DIFF
--- a/src/HelperRemap.js
+++ b/src/HelperRemap.js
@@ -157,7 +157,7 @@ export function registerBabel(babelCore){
 }
 export function getRelativePath(from, to){
   let relativePath = path.relative(path.dirname(from), to);
-  if (relativePath[0] !== '.') {
+  if (!/^\.+[\/\\]/.test(relativePath)) {
     relativePath = '.' + path.sep + relativePath;
   }
   return relativePath;


### PR DESCRIPTION
如果源文件在根目录，会得到 require('.temp_bundle_helpers.js') 的情况，导致报错。
